### PR TITLE
Compatible with Doctrine ORM >= 2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/http-kernel": "~2.3|~3.0|~4.0|~5.0",
         "symfony/dependency-injection": "~2.3|~3.0|~4.0|~5.0",
         "symfony/expression-language": "~2.3|~3.0|~4.0|~5.0",
-        "doctrine/orm": "~2.4|~2.5|~2.6"
+        "doctrine/orm": "~2.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36"

--- a/src/Service/EventPuller.php
+++ b/src/Service/EventPuller.php
@@ -50,11 +50,14 @@ class EventPuller
         foreach ($entities as $entity) {
             // ignore Doctrine not initialized proxy classes
             // proxy class can't have a domain events
-            if ((
-                    (!$entity instanceof CommonProxy && !$entity instanceof Proxy) || $entity->__isInitialized()
-                ) &&
-                $entity instanceof AggregateEvents
+            if (
+                ($entity instanceof Proxy && !$entity->__isInitialized()) ||
+                ($entity instanceof CommonProxy && !$entity->__isInitialized())
             ) {
+                continue;
+            }
+
+            if ($entity instanceof AggregateEvents) {
                 $events = array_merge($events, $entity->pullEvents());
             }
         }

--- a/src/Service/EventPuller.php
+++ b/src/Service/EventPuller.php
@@ -9,7 +9,8 @@
 
 namespace GpsLab\Bundle\DomainEvent\Service;
 
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Common\Persistence\Proxy as CommonProxy;
+use Doctrine\Persistence\Proxy;
 use Doctrine\ORM\UnitOfWork;
 use GpsLab\Domain\Event\Aggregator\AggregateEvents;
 use GpsLab\Domain\Event\Event;
@@ -45,10 +46,15 @@ class EventPuller
     private function pullFromEntities(array $entities)
     {
         $events = [];
+
         foreach ($entities as $entity) {
             // ignore Doctrine not initialized proxy classes
             // proxy class can't have a domain events
-            if ((!($entity instanceof Proxy) || $entity->__isInitialized()) && $entity instanceof AggregateEvents) {
+            if ((
+                    (!$entity instanceof CommonProxy && !$entity instanceof Proxy) || $entity->__isInitialized()
+                ) &&
+                $entity instanceof AggregateEvents
+            ) {
                 $events = array_merge($events, $entity->pullEvents());
             }
         }

--- a/tests/Fixtures/SimpleObject.php
+++ b/tests/Fixtures/SimpleObject.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * GpsLab component.
+ *
+ * @author    Peter Gribanov <info@peter-gribanov.ru>
+ * @copyright Copyright (c) 2011, Peter Gribanov
+ * @license   http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Bundle\DomainEvent\Tests\Fixtures;
+
+class SimpleObject
+{
+    /**
+     * @var string
+     */
+    private $foo;
+
+    /**
+     * @var string
+     */
+    protected $camelCase = 'boo';
+
+    /**
+     * @return string
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param string $foo
+     */
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCamelCase()
+    {
+        return $this->camelCase;
+    }
+
+    /**
+     * @param string $camelCase
+     */
+    public function setCamelCase($camelCase)
+    {
+        $this->camelCase = $camelCase;
+    }
+}

--- a/tests/Fixtures/SimpleObjectProxy.php
+++ b/tests/Fixtures/SimpleObjectProxy.php
@@ -13,7 +13,7 @@ namespace GpsLab\Bundle\DomainEvent\Tests\Fixtures;
 use Doctrine\Common\Persistence\Proxy as CommonProxy;
 use Doctrine\Persistence\Proxy;
 
-if (class_exists(CommonProxy::class)) {
+if (interface_exists(CommonProxy::class)) {
     class SimpleObjectProxy extends SimpleObject implements CommonProxy
     {
         /**

--- a/tests/Fixtures/SimpleObjectProxy.php
+++ b/tests/Fixtures/SimpleObjectProxy.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * GpsLab component.
+ *
+ * @author    Peter Gribanov <info@peter-gribanov.ru>
+ * @copyright Copyright (c) 2011, Peter Gribanov
+ * @license   http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Bundle\DomainEvent\Tests\Fixtures;
+
+use Doctrine\Common\Persistence\Proxy as CommonProxy;
+use Doctrine\Persistence\Proxy;
+
+if (class_exists(CommonProxy::class)) {
+    class SimpleObjectProxy extends SimpleObject implements CommonProxy
+    {
+        /**
+         * @var bool
+         */
+        public $__isInitialized__ = false;
+
+        public function __load()
+        {
+            if (!$this->__isInitialized__) {
+                $this->camelCase = 'proxy-boo';
+                $this->__isInitialized__ = true;
+            }
+        }
+
+        /**
+         * @return bool
+         */
+        public function __isInitialized()
+        {
+            return $this->__isInitialized__;
+        }
+    }
+} else {
+    class SimpleObjectProxy extends SimpleObject implements Proxy
+    {
+        /**
+         * @var bool
+         */
+        public $__isInitialized__ = false;
+
+        public function __load()
+        {
+            if (!$this->__isInitialized__) {
+                $this->camelCase = 'proxy-boo';
+                $this->__isInitialized__ = true;
+            }
+        }
+
+        /**
+         * @return bool
+         */
+        public function __isInitialized()
+        {
+            return $this->__isInitialized__;
+        }
+    }
+}

--- a/tests/Service/EventPullerTest.php
+++ b/tests/Service/EventPullerTest.php
@@ -9,10 +9,10 @@
 
 namespace GpsLab\Bundle\DomainEvent\Tests\Service;
 
-use Doctrine\Common\Persistence\Proxy as CommonProxy;
-use Doctrine\Persistence\Proxy;
 use Doctrine\ORM\UnitOfWork;
 use GpsLab\Bundle\DomainEvent\Service\EventPuller;
+use GpsLab\Bundle\DomainEvent\Tests\Fixtures\SimpleObject;
+use GpsLab\Bundle\DomainEvent\Tests\Fixtures\SimpleObjectProxy;
 use GpsLab\Domain\Event\Aggregator\AggregateEvents;
 use GpsLab\Domain\Event\Event;
 use PHPUnit\Framework\TestCase;
@@ -116,16 +116,16 @@ class EventPullerTest extends TestCase
 
             $map = [
                 [
-                    $this->getProxyMock(),
+                    $this->getMockBuilder(SimpleObjectProxy::class)->getMock(),
                     $aggregator1,
                 ],
                 [
                     $aggregator2,
-                    new \stdClass(),
+                    new SimpleObject(),
                 ],
                 [
-                    new \stdClass(),
-                    $this->getProxyMock(),
+                    new SimpleObject(),
+                    $this->getMockBuilder(SimpleObjectProxy::class)->getMock(),
                 ],
             ];
         } else {
@@ -189,22 +189,10 @@ class EventPullerTest extends TestCase
         ;
 
         return [
-            $this->getProxyMock(),
-            new \stdClass(),
+            $this->getMockBuilder(SimpleObjectProxy::class)->getMock(),
+            new SimpleObject(),
             $aggregator1,
             $aggregator2,
         ];
-    }
-
-    /**
-     * @return CommonProxy|Proxy|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private function getProxyMock()
-    {
-        if (class_exists(CommonProxy::class)) {
-            return $this->getMockBuilder(CommonProxy::class)->getMock();
-        }
-
-        return $this->getMockBuilder(Proxy::class)->getMock();
     }
 }

--- a/tests/Service/EventPullerTest.php
+++ b/tests/Service/EventPullerTest.php
@@ -9,7 +9,8 @@
 
 namespace GpsLab\Bundle\DomainEvent\Tests\Service;
 
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Common\Persistence\Proxy as CommonProxy;
+use Doctrine\Persistence\Proxy;
 use Doctrine\ORM\UnitOfWork;
 use GpsLab\Bundle\DomainEvent\Service\EventPuller;
 use GpsLab\Domain\Event\Aggregator\AggregateEvents;
@@ -115,7 +116,7 @@ class EventPullerTest extends TestCase
 
             $map = [
                 [
-                    $this->getMockBuilder(Proxy::class)->getMock(),
+                    $this->getProxyMock(),
                     $aggregator1,
                 ],
                 [
@@ -124,7 +125,7 @@ class EventPullerTest extends TestCase
                 ],
                 [
                     new \stdClass(),
-                    $this->getMockBuilder(Proxy::class)->getMock(),
+                    $this->getProxyMock(),
                 ],
             ];
         } else {
@@ -188,10 +189,22 @@ class EventPullerTest extends TestCase
         ;
 
         return [
-            $this->getMockBuilder(Proxy::class)->getMock(),
+            $this->getProxyMock(),
             new \stdClass(),
             $aggregator1,
             $aggregator2,
         ];
+    }
+
+    /**
+     * @return CommonProxy|Proxy|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getProxyMock()
+    {
+        if (class_exists(CommonProxy::class)) {
+            return $this->getMockBuilder(CommonProxy::class)->getMock();
+        }
+
+        return $this->getMockBuilder(Proxy::class)->getMock();
     }
 }


### PR DESCRIPTION
The `doctrine/orm` version `2.7` and later use `doctrine/persistence` package and uses `Doctrine\Persistence\Proxy` class instead of `Doctrine\Common\Persistence\Proxy`.